### PR TITLE
Allow setting organizationId in testimonial table to "undefined"

### DIFF
--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -13,7 +13,7 @@ export const setDefaultApprovedValue = migrations.define({
 });
 
 export const setTestimonialOrganizationId = internalMutation({
-  args: { organizationId: v.string() },
+  args: { organizationId: v.optional(v.string()) },
   handler: async (ctx, { organizationId }) => {
     const testimonials = await ctx.db.query("testimonials").collect();
     for (const testimonial of testimonials) {


### PR DESCRIPTION
Allow setting organizationId in testimonial table to "undefined" in setTestimonialOrganizationId function