### PR TITLE
[CFA-58] Fix notion integration

### DIFF
--- a/.github/workflows/update-to-notion.yml
+++ b/.github/workflows/update-to-notion.yml
@@ -1,6 +1,12 @@
 name: Update to Notion
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+      - edited
 
 jobs:
   update-on-notion:


### PR DESCRIPTION
By default, GitHub only triggers action when PR is opened, reopened and synchronize. This adds more PR trigger types to the action
- `closed`: when PR is closed
- `edited`: when PR title or description is updated