### PR TITLE
[CFA-87] Fixed download audio/video option rendering logic

### DIFF
--- a/components/testimonial-detail/testimonial-download.tsx
+++ b/components/testimonial-detail/testimonial-download.tsx
@@ -71,7 +71,7 @@ export default function TestimonialDownload() {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
-        {hasMedia !== "text" && (
+        {hasMedia && (
           <DropdownMenuItem onClick={downloadMedia} className="cursor-pointer">
             {testimonial.media_type === "video" ? (
               <VideoIcon />
@@ -87,7 +87,7 @@ export default function TestimonialDownload() {
           className="cursor-pointer"
         >
           <FileText />
-          Download {hasMedia ? "Trascription" : "Testimonial"}
+          Download {hasMedia ? "Transcription" : "Testimonial"}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
Fixed download audio/video option rendering logic to in testimonial details to only show the option is media is present. Also fixed typo for Download Transcription option.