### PR TITLE
Bugfix/fix testimonial detail live update

### DIFF
--- a/app/routes/testimonials/$id.tsx
+++ b/app/routes/testimonials/$id.tsx
@@ -68,11 +68,6 @@ export default function TestimonialDetail() {
       id: id,
     }),
   );
-  const { data: canView } = useSuspenseQuery(
-    hasPermissionQuery({
-      testimonial: ["view"],
-    }),
-  );
 
   const { data: canApprove } = useSuspenseQuery(
     hasPermissionQuery({
@@ -92,9 +87,6 @@ export default function TestimonialDetail() {
     }),
   );
   const testimonial = liveTestimonial || preloadTestimonial;
-  if (!testimonial || (!canView && !testimonial.approved)) {
-    return <NotFound />;
-  }
 
   return (
     <TestimonialContext.Provider value={{ testimonial }}>

--- a/app/routes/testimonials/tmp.$id.tsx
+++ b/app/routes/testimonials/tmp.$id.tsx
@@ -57,16 +57,10 @@ function Component() {
     }),
   );
   const testimonial = liveTestimonial || preloadTestimonial;
-  if (!testimonial) {
-    return <NotFound />;
-  }
 
   // _creationTime is the milliseconds since unix epoch when the document was created. 15 minutes = 900,000 milliseconds
   const liveExpirationDate = testimonial._creationTime + 900_000;
   const expirationDate = liveExpirationDate || preloadExpirationDate;
-  if (Date.now() >= expirationDate) {
-    return <NotFound />;
-  }
   return (
     <div className="max-w-xl mx-auto py-12 px-8 space-y-4">
       <Button variant="link" className="px-0!" asChild>


### PR DESCRIPTION
Addressing a staging bug in which [testimonial detail live updates were not working](https://github.com/City-Reach/club-freedom/issues/120), and required users to refresh the page to see the latest data. To test the fixes, do the following:

For testimonial submission poster:
1. Submit a testimonial. This should take you to the temporary testimonial details page.
2. The tmp testimonials detail page should auto update without the user refreshing the page.

For admins:

1. Sign in to an admin account.
2. Navigate to any existing testimonial details page.
3. Change the approval. The status should update without needing to refresh the page.

Fix #120