### PR TITLE
Improvement/create any user

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,7 +13,7 @@ import type * as auth from "../auth.js";
 import type * as email from "../email.js";
 import type * as functions from "../functions.js";
 import type * as http from "../http.js";
-import type * as internal_createAdminUser from "../internal/createAdminUser.js";
+import type * as internal_createUser from "../internal/createUser.js";
 import type * as internal_organizations from "../internal/organizations.js";
 import type * as media from "../media.js";
 import type * as mediaProcessing from "../mediaProcessing.js";
@@ -36,7 +36,7 @@ declare const fullApi: ApiFromModules<{
   email: typeof email;
   functions: typeof functions;
   http: typeof http;
-  "internal/createAdminUser": typeof internal_createAdminUser;
+  "internal/createUser": typeof internal_createUser;
   "internal/organizations": typeof internal_organizations;
   media: typeof media;
   mediaProcessing: typeof mediaProcessing;

--- a/convex/internal/createUser.ts
+++ b/convex/internal/createUser.ts
@@ -2,11 +2,12 @@ import { v } from "convex/values";
 import { authComponent, createAuth } from "../auth";
 import { mutation } from "../functions";
 
-export const createAdminUser = mutation({
+export const createUser = mutation({
   args: {
     name: v.string(),
     email: v.string(),
     password: v.string(),
+    role: v.union(v.literal("user"), v.literal("admin")),
   },
   handler: async (ctx, args) => {
     const { auth } = await authComponent.getAuth(createAuth, ctx);
@@ -15,7 +16,7 @@ export const createAdminUser = mutation({
         name: args.name,
         email: args.email,
         password: args.password,
-        role: "admin",
+        role: args.role,
       },
     });
   },


### PR DESCRIPTION
Allow devs to create a user with any role. This is to prepare for the following organization onboarding flow:

1. If the owner doesn't have an account, create an account for them with better auth's createUser function (https://www.better-auth.com/docs/plugins/admin#api-method-admin-create-user). We have an internal function for this at convex/internal/createUser.ts
2. Create an organization with better auth's createOrganization function (https://www.better-auth.com/docs/plugins/organization#api-method-organization-create), while passing in the user id of the target account and omitting headers. We already have a UI for creating orgs, but it can be tweaked so we can specify which user id to have as the initial org owner. Alternatively, we can use the internal function in convex\internal\organizations.ts