### PR TITLE
Fix agreement checkbox not working when no preferences provided

### DIFF
--- a/components/testimonial-form/index.tsx
+++ b/components/testimonial-form/index.tsx
@@ -10,7 +10,7 @@ import {
 import { useServerFn } from "@tanstack/react-start";
 import { useMutation } from "convex/react";
 import { formatDistance } from "date-fns";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Controller, FormProvider, useForm } from "react-hook-form";
 import Markdown from "react-markdown";
 import { toast } from "sonner";
@@ -73,12 +73,6 @@ export default function TestimonialForm() {
     },
     resolver: zodResolver(testimonialSchema),
   });
-
-  useEffect(() => {
-    if (agreements.length > 0) {
-      form.setValue("agreementsAccepted", []);
-    }
-  }, [agreements, form.setValue]);
 
   const navigation = useNavigate();
   const uploadFile = useUploadFile();


### PR DESCRIPTION
## Root cause

The `useEffect` in `testimonial-form/index.tsx` causes the infinite loop, making the agreement checkbox not interactive