### PR TITLE
Fix logo size on mobile

### DIFF
--- a/components/layouts/organization/organization-info.tsx
+++ b/components/layouts/organization/organization-info.tsx
@@ -29,7 +29,7 @@ export default function OrganizationInfo() {
           src={organization.logo}
           alt={organization.name}
           height={32}
-          className="size-full"
+          className="h-full"
         />
       </div>
     );


### PR DESCRIPTION
Logo get stretch out on mobile because of 100% width. Removing this should fix the issue

## Before

<img width="585" height="1266" alt="BAM Vancouver" src="https://github.com/user-attachments/assets/765ec14a-1b64-4ab1-a381-9a8a2b0a2cb3" />

## After

<img width="585" height="1266" alt="BAM Vancouver 2" src="https://github.com/user-attachments/assets/f8ba9b1a-1493-465c-a1a9-19536d53e296" />
