### PR TITLE
Hotfix: transparent sidebar background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -76,11 +76,7 @@
   --input: color-mix(in oklch, var(--foreground) 15%, var(--background));
   --ring: var(--primary);
 
-  --sidebar-background: color-mix(
-    in oklch,
-    var(--background) 98%,
-    var(--foreground)
-  );
+  --sidebar: color-mix(in oklch, var(--background) 95%, var(--foreground));
   --sidebar-foreground: var(--foreground);
   --sidebar-primary: color-mix(
     in oklch,


### PR DESCRIPTION
Fix transparent sidebar background in mobile version

Before

<img width="2964" height="4324" alt="image" src="https://github.com/user-attachments/assets/8b01b52d-988b-4ac2-8b58-124a3af81008" />


After

<img width="2952" height="4324" alt="image" src="https://github.com/user-attachments/assets/e57a13c2-9034-46a8-bbec-14d093bb53a6" />
